### PR TITLE
Add trim to remote repository url

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -28,7 +28,7 @@ export default class GHSyncPlugin extends Plugin {
 	{
 		new Notice("Syncing to GitHub remote")
 
-		const remote = this.settings.remoteURL;
+		const remote = this.settings.remoteURL.trim();
 
 		simpleGitOptions = {
 			//@ts-ignore


### PR DESCRIPTION
Hi Kevin, I've run into an issue during your plugin setting. I've noticed that remote url contained a white space as first char. Removing the white space fixed the issue, so I thought that adding trim() would solve it